### PR TITLE
add a default timeout of 60 secs that can be overriden, as per python

### DIFF
--- a/economic/query.py
+++ b/economic/query.py
@@ -5,7 +5,7 @@ from economic.utils import economic_request
 
 class QueryMixin(object):
     @classmethod
-    def _query(cls, auth, base_url, page_size=1000, limit=None, reverse=False, filters=None):
+    def _query(cls, auth, base_url, page_size=1000, limit=None, reverse=False, filters=None, timeout=60):
         assert page_size <= 1000, "Max 1000 items per page allowed. The generator will automatically fetch extra pages."
         if limit is not None:
             assert isinstance(limit, int), "limit argument must be an integer, it is %s" % type(limit)
@@ -41,7 +41,7 @@ class QueryMixin(object):
             # an extra query is required when using reverse so we can determine the last page
             reverse_request_params = request_params.copy()
             reverse_request_params['pagesize'] = 1  # make a fast query
-            request = economic_request(auth, base_url, request_params=reverse_request_params)
+            request = economic_request(auth, base_url, request_params=reverse_request_params, timeout=timeout)
             total_items = request['pagination']['results']
             if not limit or limit > total_items:
                 limit = total_items
@@ -54,7 +54,7 @@ class QueryMixin(object):
 
         while limit is None or items_returned < limit:
             request_params['skippages'] = page
-            request = economic_request(auth, base_url, request_params=request_params)
+            request = economic_request(auth, base_url, request_params=request_params, timeout=timeout)
             total_items = request['pagination']['results']
             if limit is None or limit > total_items:
                 limit = total_items
@@ -67,14 +67,14 @@ class QueryMixin(object):
             page += page_direction
 
     @classmethod
-    def all(cls, auth, page_size=1000, limit=None, reverse=False):
+    def all(cls, auth, page_size=1000, limit=None, reverse=False, timeout=60):
         """
         Returns a generator that on-demand fetches `limit` number of items, at max `page_size` at a time.
         """
-        return cls._query(auth, cls.base_url, page_size=page_size, limit=limit, reverse=reverse)
+        return cls._query(auth, cls.base_url, page_size=page_size, limit=limit, reverse=reverse, timeout=timeout)
 
     @classmethod
-    def filter(cls, auth, base_url=None, page_size=1000, limit=None, reverse=False, **kwargs):
+    def filter(cls, auth, base_url=None, page_size=1000, limit=None, reverse=False, timeout=60, **kwargs):
         """
         Returns a generator that on-demand fetches `limit` number of items, at max `page_size` at a time.
 
@@ -86,12 +86,12 @@ class QueryMixin(object):
         if not base_url:
             base_url = cls.base_url
         filters = {kwarg: val for kwarg, val in kwargs.items()}
-        return cls._query(auth, base_url, page_size=page_size, limit=limit, reverse=reverse, filters=filters)
+        return cls._query(auth, base_url, page_size=page_size, limit=limit, reverse=reverse, filters=filters, timeout=60)
 
     @classmethod
-    def get(cls, auth, object_id, **kwargs):
+    def get(cls, auth, object_id, timeout=60, **kwargs):
         """
         Returns one item with the specified ID.
         """
-        request = economic_request(auth, urlparse.urljoin(cls.base_url, str(object_id)))
+        request = economic_request(auth, urlparse.urljoin(cls.base_url, str(object_id)), timeout=timeout)
         return cls(auth, request)

--- a/economic/utils.py
+++ b/economic/utils.py
@@ -23,14 +23,15 @@ class ResourceDoesNotExist(EconomicAPIException):
     pass
 
 
-def economic_request(auth, url, request_params=None):
+def economic_request(auth, url, request_params=None, timeout=60):
     if not request_params:
         request_params = {}
     url = u'%s?%s' % (url, u'&'.join([u'%s=%s' % (field, value) for field, value in request_params.items()]))
     r = requests.get(
         url,
         data=json.dumps({}),
-        headers={'content-type': 'application/json', 'appId': auth.app_id, 'accessId': auth.token}
+        headers={'content-type': 'application/json', 'appId': auth.app_id, 'accessId': auth.token},
+        timeout=timeout
     )
     if r.status_code == 200:
         return json.loads(r.content)


### PR DESCRIPTION
requests documentation:"You can tell Requests to stop waiting for a response after a given number of seconds with the timeout parameter. Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely" http://docs.python-requests.org/en/master/user/quickstart/